### PR TITLE
Material icon widget

### DIFF
--- a/s1panel/config.json
+++ b/s1panel/config.json
@@ -64,7 +64,8 @@
       "widgets/line_chart.js",
       "widgets/doughnut_chart.js",
       "widgets/bar_chart.js",
-      "widgets/image.js"
+      "widgets/image.js",
+      "widgets/material_icon.js"
    ],
    "canvas": {
       "width": 320,

--- a/s1panel/themes/simple_demo/portrait_simple.json
+++ b/s1panel/themes/simple_demo/portrait_simple.json
@@ -34,15 +34,18 @@
             {
                "id": 2,
                "group": 1,
-               "name": "image",
+               "name": "material_icon",
+               "value": "memory",
+               "color": "#878787",
+               "family": "baseline",
                "rect": {
-                  "x": 65,
-                  "y": 35,
-                  "width": 40,
-                  "height": 40
+                  "x": 60,
+                  "y": 30,
+                  "width": 50,
+                  "height": 50
                },
-               "value": "themes/simple_demo/cpu.png",
                "refresh": 0,
+               "sensor": false,
                "debug_frame": false
             },
             {
@@ -66,14 +69,17 @@
             {
                "id": 4,
                "group": 2,
-               "name": "image",
+               "name": "material_icon",
+               "value": "thermostat",
+               "color": "#878787",
+               "family": "baseline",
                "rect": {
-                  "x": 70,
-                  "y": 134,
-                  "width": 34,
-                  "height": 51
+                  "x": 60,
+                  "y": 135,
+                  "width": 50,
+                  "height": 50
                },
-               "value": "themes/simple_demo/temp.png",
+               "sensor": false,
                "refresh": 0,
                "debug_frame": false
             },
@@ -98,14 +104,17 @@
             {
                "id": 6,
                "group": 3,
-               "name": "image",
+               "name": "material_icon",
+               "value": "lightbulb",
+               "color": "#878787",
+               "family": "outline",
                "rect": {
-                  "x": 70,
-                  "y": 243,
-                  "width": 40,
-                  "height": 40
+                  "x": 60,
+                  "y": 238,
+                  "width": 50,
+                  "height": 50
                },
-               "value": "themes/simple_demo/lightbulb.png",
+               "sensor": false,
                "refresh": 0,
                "debug_frame": false
             },

--- a/s1panel/widgets/material_icon.js
+++ b/s1panel/widgets/material_icon.js
@@ -1,0 +1,155 @@
+'use strict';
+/*!
+ * s1panel - widget/image
+ * Copyright (c) 2024 Tomasz Jaworski
+ * GPL-3 Licensed
+ */
+const node_canvas = require('canvas');
+
+function replaceRootSVGProperties(svgData, properties) {
+
+    const groups = /^<svg ([^>]*)>/.exec(svgData);
+
+    const newProperties = [];
+
+    for(let prop of groups[1].split(' ')) {
+
+        let filteredOut = false;
+
+        for (let key in properties) {
+
+            if (prop.match(key)) {
+
+                filteredOut = true;
+                break;
+            }
+        }
+
+        if (!filteredOut) {
+
+            newProperties.push(prop);
+        }
+    }
+
+    for (let key in properties) {
+        
+        const value = properties[key];
+        newProperties.push(`${key}='${value}'`);
+    }
+
+    return svgData.replace(/^<svg [^>]*>/, `<svg ${newProperties.join(' ')}>`);
+}
+
+function load_icon(name, family, _private) {
+
+    return new Promise((fulfill, reject) => {
+
+        const slug = `${name}/${family}`;
+
+        if (_private.icons[slug]) {
+
+            return fulfill(_private.icons[slug]);
+        }
+
+        const url = `https://material-icons.github.io/material-icons/svg/${slug}.svg`;
+
+        fetch(url).then(response => {
+
+            if (response.status !== 200) {
+
+                return reject();
+            }
+
+            return response.text().then((image) => {
+
+                _private.icons[slug] = image;
+    
+                return fulfill(image);
+            });
+        
+        }, (error) => {
+            reject();
+        });
+    });
+}
+
+function get_private(config) {
+
+    if (!config._private) {
+
+        config._private = {
+            icons: {}
+        };
+    }
+
+    return config._private;
+}
+
+function draw(context, value, min, max, config) {
+
+    return new Promise(fulfill => {
+
+        const _private = get_private(config);
+
+        const _rect = config.rect;
+
+        context.save();
+        context.beginPath();
+        context.rect(_rect.x, _rect.y, _rect.width, _rect.height);
+        context.clip();
+
+        const color = config.color || '#ffffff';
+        
+        load_icon(value, config.family, _private).then(image => {
+
+            image = replaceRootSVGProperties(image, {
+                width: _rect.width,
+                height: _rect.height,
+                fill: color,
+            });
+
+            node_canvas.loadImage(`data:image/svg+xml,${image}`).then((loadedImage) => {
+
+                context.drawImage(loadedImage, _rect.x, _rect.y, _rect.width, _rect.height);
+
+                if (config.debug_frame) {
+
+                    context.lineWidth = 1;
+                    context.strokeStyle = "red";
+                    context.rect(_rect.x, _rect.y, _rect.width, _rect.height);
+                    context.stroke();
+                }
+                
+                context.restore();
+                
+                fulfill(false);
+            }, () => {
+
+                context.restore();
+
+                fulfill(false);
+            });
+        }, () => {
+
+            context.restore();
+
+            fulfill(false);
+        });
+    }); 
+}
+
+function info() {
+    return {
+        name: 'material_icon',
+        description: 'a material icon svg',
+        fields: [
+            { name: "family", value: "list:baseline,sharp,outline,round,two-tone" },
+            { name: "color", value: "color" }
+        ]
+    };
+}
+
+module.exports = {
+    info,
+    draw
+};


### PR DESCRIPTION
I added a widget to display any material icon.
`value` is the icon name
`family` is the icon style (baseline, outline, sharp, round, two-tone)
`color` is the icon color

Available icons can be searched here https://icon-sets.iconify.design/ic/

Here's what the example screen looks like with icons instead of the previously used images: 
![Capture d'écran 2024-05-24 212542](https://github.com/tjaworski/AceMagic-S1-LED-TFT-Linux/assets/119354/43eb323f-d249-450d-8d89-b06aa36c6b09)
