### PR TITLE
add option to ignore led

### DIFF
--- a/s1panel/led_thread.js
+++ b/s1panel/led_thread.js
@@ -32,6 +32,12 @@ threads.parentPort.on('message', message => {
         case 5:
             _promise = led.set_automatic(message.device, message.intensity, message.speed);
             break;
+
+        case 6:
+            // ignore
+            logger.info('led_thread: ignore');
+            _promise = Promise.resolve();
+            break;
     }
 
     return _promise;


### PR DESCRIPTION
Added option to ignore the led strip by setting config option, e.g., when handling the led with a python script