### PR TITLE
feat: add new sensors, fix theme switching, and improve installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Dependencies
+node_modules/
+s1panel/node_modules/
+s1panel/gui/node_modules/
+
+# Build output
+s1panel/gui/dist/
+
+# Snap build artifacts
+s1panel/snap/.snapcraft/
+parts/
+stage/
+prime/
+*.snap
+
+# Logs
+*.log
+npm-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Runtime / generated fonts config
+s1panel/fonts.conf

--- a/CHANGES_FORK.md
+++ b/CHANGES_FORK.md
@@ -1,0 +1,579 @@
+# CHANGES_FORK.md
+
+Documentation of all changes, additions, and fixes made to the original repository
+[AceMagic-S1-LED-TFT-Linux](https://github.com/tjaworski/AceMagic-S1-LED-TFT-Linux).
+
+---
+
+## 1. Required system packages
+
+### Mandatory (runtime)
+
+| Package | Usage |
+|---|---|
+| `network-manager` | Provides the `nmcli` command, required by `wifi_signal.js` |
+| `udev` | Rules for the persistent symlink `/dev/acemagic-led` |
+| `systemd` | Management of the `s1panel.service` service |
+| `libusb-1.0-0` | Access to the LCD panel USB device |
+| `libcairo2` | Canvas rendering (native library for the `canvas` npm package) |
+| `libpango-1.0-0` | Fonts and text in canvas |
+| `libjpeg8` or `libjpeg-turbo8` | JPEG support in canvas |
+| `libgif7` | GIF support in canvas |
+| `librsvg2-2` | SVG support in canvas |
+
+### Mandatory (native npm module compilation)
+
+| Package | Usage |
+|---|---|
+| `build-essential` | `gcc`, `make`, etc. to compile native modules (`canvas`, `serialport`) |
+| `python3` | Required by `node-gyp` to compile modules |
+| `libcairo2-dev` | Cairo headers for compiling `canvas` |
+| `libpango1.0-dev` | Pango headers for compiling `canvas` |
+| `libjpeg-dev` | JPEG headers for compiling `canvas` |
+| `libgif-dev` | GIF headers for compiling `canvas` |
+| `librsvg2-dev` | SVG headers for compiling `canvas` |
+| `libusb-1.0-0-dev` | USB headers for compiling `@serialport/bindings-cpp` |
+| `libudev-dev` | udev headers for compiling `@serialport/bindings-cpp` |
+
+### Node.js (via NVM)
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+nvm install 20.19.5
+nvm use 20.19.5
+```
+
+### Quick install (Debian/Ubuntu)
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  network-manager udev systemd \
+  libusb-1.0-0 libcairo2 libpango-1.0-0 libjpeg8 libgif7 librsvg2-2 \
+  build-essential python3 \
+  libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+  libusb-1.0-0-dev libudev-dev
+```
+
+---
+
+## 2. Web interface changes
+
+### `s1panel/gui/src/assets/main.css`
+
+**New two-column layout:**
+
+- `html` and `body` set to `height: 100%; overflow: hidden` to prevent unwanted body scroll.
+- Added class `.layout-root`: main flex container (`display: flex`, `height: 100vh`, `overflow: hidden`, `gap: 0.75rem`, `padding: 0.75rem`).
+- Added class `.panel-left`: left scrollable panel (`flex: 1`, `overflow-y: auto`), contains all widget/sensor configuration.
+- Added class `.panel-right`: fixed right panel 380 px wide (`overflow-y: auto`, `flex-direction: column`), contains the LCD preview and global settings.
+- Added custom scrollbar style for both panels (5 px wide, transparent background, dark grey thumb).
+
+**New loading overlay:**
+
+- Added class `.loading-overlay`: `fixed` position, covers the entire screen (`inset: 0`), semi-transparent black background (`rgba(0,0,0,0.75)`), `z-index: 9999`, centered with flexbox.
+- Added class `.loading-content`: centered column with white text to display the spinner and message.
+
+---
+
+### `s1panel/gui/src/App.vue`
+
+**Two-column layout:**
+
+- The main structure was migrated from a PrimeFlex grid (`<div class="p-3"><div class="grid fluid">`) to a `<div class="layout-root">` container.
+- **Right panel** (`.panel-right`, 380 px, fixed): contains the LCD preview card and the Settings card.
+- **Left panel** (`.panel-left`, flex-1, scrollable): contains the Configuration card with the full widget/sensor accordion.
+- The result is that the preview and settings are always visible while editing the configuration.
+
+**Theme change fix (`onThemeChange`):**
+
+- Before: `onThemeChange()` was an empty function (only `console.log`).
+- Now:
+  1. Queries `/api/config_dirty` to detect unsaved changes.
+  2. If there are unsaved changes, shows a confirmation dialog (group `headless2`) asking whether to save or discard.
+  3. In either case calls `_doSwitch()`: saves the theme via `api.save_config({ theme })` and reloads the page.
+
+**Loading overlay on theme change:**
+
+- Added reactive property `loading: { show: false, message: '' }` in `data()`.
+- Before calling `api.save_config()`, `loading.show = true` is activated with the message `"Applying theme, please wait..."`.
+- The template displays the overlay with a PrimeVue `<ProgressSpinner>` while the service restarts and the page reloads.
+
+---
+
+## 3. Sensor changes
+
+### `sensors/cpu_freq.js` — **NEW**
+
+Sensor that monitors the current CPU frequency (core 0) via sysfs.
+
+**Data source:** `/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq`
+
+**Configuration:**
+
+| Field | Type | Description | Default |
+|---|---|---|---|
+| `max_points` | number | Number of samples in history | 300 |
+
+**Format fields `{N}`:**
+
+| Token | Description | Unit |
+|---|---|---|
+| `{0}` | Current CPU frequency | MHz |
+| `{1}` | Frequency history (for sparkline/chart) | MHz |
+
+**Reported `min`/`max`:** 0 – `scaling_max_freq` read at startup (auto-detected from sysfs).
+
+---
+
+### `sensors/cpu_temp.js` — **EXTENDED**
+
+Individual per-core temperature reading was added.
+
+**Changes from original:**
+
+- New module variable `_core_temps = []`.
+- During the hwmon walk, now also collects all paths whose label starts with `"Core "` (in addition to `"Package id 0"`).
+- Reads in parallel `temp_input` from Package + all cores in a single `Promise.all`.
+- `get_current_value()` updates `_core_temps` with values rounded to integer.
+
+**New format fields `{N}`:**
+
+| Token | Description |
+|---|---|
+| `{3}` | Core 0 temperature (°C or °F depending on config) |
+| `{4}` | Core 1 temperature |
+| `{5}` | Core 2 temperature |
+| `{6}` | Core 3 temperature |
+
+The previous tokens `{0}`, `{1}`, `{2}` are unchanged (Package, history, unit).
+
+---
+
+### `sensors/memory.js` — **MODIFIED**
+
+**Change in `usage` precision:**
+
+- Before: `usage` was calculated with `.toFixed(2)` → showed values like `28.65%`.
+- Now: `usage` uses `.toFixed(0)` → shows integer values like `28%`.
+
+The rest of the logic and format fields are unchanged.
+
+---
+
+### `sensors/nvme_temp.js` — **NEW**
+
+Sensor that monitors NVMe SSD temperature via hwmon/sysfs.
+
+**Data source:** `/sys/class/hwmon/hwmonX/` where `name == 'nvme'`, label `'Composite'`.
+
+**Configuration:**
+
+| Field | Type | Description | Default |
+|---|---|---|---|
+| `max_points` | number | Number of samples in history | 300 |
+| `fahrenheit` | boolean | Display in Fahrenheit | `false` |
+
+**Format fields `{N}`:**
+
+| Token | Description | Unit |
+|---|---|---|
+| `{0}` | Current Composite temperature | °C or °F |
+| `{1}` | Temperature history (for sparkline/chart) | °C or °F |
+| `{2}` | Unit character | `"C"` or `"F"` |
+
+**Reported `min`/`max`:** 20 °C (68 °F) – device critical temperature (read from `temp_crit`, default 84 °C if file does not exist).
+
+---
+
+### `sensors/space.js` — **MODIFIED**
+
+**Compatibility with older Node.js versions:**
+
+- Before: exclusively used `fs.statfs()`, available only since Node.js ≥ 19.6.
+- Now: detects at runtime whether `fs.statfs` exists; if not, uses `exec('df -B1 <mount_point>')` as fallback for older versions.
+
+**Value precision:**
+
+- Added property `precision: 0` in the `_private` object, so percentages and MB are displayed without decimals.
+
+**Format fields `{N}` are unchanged.**
+
+---
+
+### `sensors/wifi_signal.js` — **NEW**
+
+Sensor that monitors WiFi signal and connection status using `nmcli`.
+
+**Data source:** `nmcli -t -f IN-USE,SSID,SIGNAL,CHAN,RATE dev wifi`
+
+**Configuration:**
+
+| Field | Type | Description | Default |
+|---|---|---|---|
+| `interface` | string | WiFi interface (for identification only, nmcli reads the active network) | `"wlp3s0"` |
+| `max_points` | number | Number of samples in history | 300 |
+
+**Format fields `{N}`:**
+
+| Token | Description | Example |
+|---|---|---|
+| `{0}` | Network name (SSID) | `"MyNetwork_5G"` |
+| `{1}` | Signal strength (0–100) | `72` |
+| `{2}` | WiFi channel | `36` |
+| `{3}` | Link speed | `"270 Mbit/s"` |
+| `{4}` | Signal history (for sparkline/chart) | `0,0,72,71,...` |
+| `{5}` | Connection status | `"online"` / `"offline"` |
+
+**Reported `min`/`max`:** 0 – 100 (signal percentage).
+
+---
+
+## 4. API, configuration, and installer changes
+
+### `s1panel/api.js` — **MODIFIED**
+
+**Fix in `save_config`:**
+
+- Before: the `theme` field was completely ignored in `save_config()`; changing the theme from the GUI did not persist it nor restart the service.
+- Now: `request.theme` is evaluated. If the value differs from the active theme, `_live_config.theme` and `_file_config.theme` are updated, `config.json` is persisted, and `_restart = true` is set.
+- When the service runs as a daemon (`SERVICE=true`), `_restart = true` triggers `process.exit(1)`, allowing systemd to restart the process with the new theme loaded.
+
+---
+
+### `s1panel/config.json` — **MODIFIED**
+
+**Added sensors:**
+
+| Sensor | Key config |
+|---|---|
+| `sensors/cpu_freq.js` | `max_points: 300` |
+| `sensors/nvme_temp.js` | `max_points: 300`, `fahrenheit: false` |
+| `sensors/wifi_signal.js` | `interface: "wlp3s0"`, `max_points: 300` |
+
+**Other changes:**
+
+| Field | Before | Now |
+|---|---|---|
+| `led_config.device` | `"/dev/ttyUSB0"` | `"/dev/acemagic-led"` (persistent udev symlink) |
+| `heartbeat` | (absent) | `60000` ms — periodic LED command resend |
+| Network interface | `"enp2s0"` / `"wlp2s0"` | `"enp2s0"` / `"wlp3s0"` (actual WiFi interface name) |
+
+---
+
+### `s1panel/install` — **REWRITTEN**
+
+The install script was completely rewritten to:
+
+1. **Use NVM**: automatically loads `~/.nvm/nvm.sh` and activates Node.js v20.19.5 before any operation.
+2. **Build the GUI**: runs `npm i` and `npm run build` in the `gui/` directory as part of the installation.
+3. **Dynamically detect the Node path**: uses `which node` to get the absolute path of the binary and write it to the systemd service file, ensuring the service uses the correct Node version regardless of the system PATH.
+4. **systemd service management**: generates the `/etc/systemd/system/s1panel.service` file using `sudo tee`, then runs `daemon-reload`, `enable`, and `start` in sequence.
+
+---
+
+## 5. `.gitignore` file — **NEW**
+
+A `.gitignore` was added at the repository root with the following exclusions:
+
+| Pattern | Reason |
+|---|---|
+| `node_modules/`, `s1panel/node_modules/`, `s1panel/gui/node_modules/` | npm dependencies should not be versioned |
+| `s1panel/gui/dist/` | Frontend build artifact |
+| `s1panel/snap/.snapcraft/`, `parts/`, `stage/`, `prime/`, `*.snap` | Snap build artifacts |
+| `*.log`, `npm-debug.log*` | Runtime logs |
+| `.DS_Store`, `Thumbs.db` | Operating system files |
+| `.vscode/`, `.idea/`, `*.swp`, `*.swo` | Editor configuration |
+| `s1panel/fonts.conf` | Automatically generated at runtime |
+
+---
+
+---
+
+# CHANGES_FORK.md (Español)
+
+Documentación de todos los cambios, adiciones y correcciones realizados sobre el repositorio original
+[AceMagic-S1-LED-TFT-Linux](https://github.com/tjaworski/AceMagic-S1-LED-TFT-Linux).
+
+---
+
+## 1. Paquetes del sistema requeridos
+
+### Obligatorios (runtime)
+
+| Paquete | Uso |
+|---|---|
+| `network-manager` | Provee el comando `nmcli`, requerido por `wifi_signal.js` |
+| `udev` | Reglas para el symlink persistente `/dev/acemagic-led` |
+| `systemd` | Gestión del servicio `s1panel.service` |
+| `libusb-1.0-0` | Acceso al dispositivo USB del panel LCD |
+| `libcairo2` | Renderizado de canvas (librería nativa del paquete npm `canvas`) |
+| `libpango-1.0-0` | Fuentes y texto en canvas |
+| `libjpeg8` o `libjpeg-turbo8` | Soporte JPEG en canvas |
+| `libgif7` | Soporte GIF en canvas |
+| `librsvg2-2` | Soporte SVG en canvas |
+
+### Obligatorios (compilación de módulos nativos npm)
+
+| Paquete | Uso |
+|---|---|
+| `build-essential` | `gcc`, `make`, etc. para compilar módulos nativos (`canvas`, `serialport`) |
+| `python3` | Requerido por `node-gyp` para compilar módulos |
+| `libcairo2-dev` | Headers de Cairo para compilar `canvas` |
+| `libpango1.0-dev` | Headers de Pango para compilar `canvas` |
+| `libjpeg-dev` | Headers JPEG para compilar `canvas` |
+| `libgif-dev` | Headers GIF para compilar `canvas` |
+| `librsvg2-dev` | Headers SVG para compilar `canvas` |
+| `libusb-1.0-0-dev` | Headers USB para compilar `@serialport/bindings-cpp` |
+| `libudev-dev` | Headers udev para compilar `@serialport/bindings-cpp` |
+
+### Node.js (via NVM)
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+nvm install 20.19.5
+nvm use 20.19.5
+```
+
+### Instalación rápida (Debian/Ubuntu)
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  network-manager udev systemd \
+  libusb-1.0-0 libcairo2 libpango-1.0-0 libjpeg8 libgif7 librsvg2-2 \
+  build-essential python3 \
+  libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+  libusb-1.0-0-dev libudev-dev
+```
+
+---
+
+## 2. Cambios de interfaz web
+
+### `s1panel/gui/src/assets/main.css`
+
+**Nuevo layout de dos columnas:**
+
+- `html` y `body` configurados con `height: 100%; overflow: hidden` para evitar scroll indeseado en el body.
+- Añadida clase `.layout-root`: contenedor flex principal (`display: flex`, `height: 100vh`, `overflow: hidden`, `gap: 0.75rem`, `padding: 0.75rem`).
+- Añadida clase `.panel-left`: panel scrollable izquierdo (`flex: 1`, `overflow-y: auto`), contiene toda la configuración de widgets/sensores.
+- Añadida clase `.panel-right`: panel fijo derecho de ancho 380 px (`overflow-y: auto`, `flex-direction: column`), contiene la vista previa del LCD y los settings globales.
+- Añadido estilo de scrollbar personalizado para ambos paneles (5 px de ancho, fondo transparente, thumb gris oscuro).
+
+**Nuevo overlay de carga:**
+
+- Añadida clase `.loading-overlay`: posición `fixed`, cubre toda la pantalla (`inset: 0`), fondo semitransparente negro (`rgba(0,0,0,0.75)`), `z-index: 9999`, centrado con flexbox.
+- Añadida clase `.loading-content`: columna centrada con texto blanco para mostrar el spinner y el mensaje.
+
+---
+
+### `s1panel/gui/src/App.vue`
+
+**Layout de dos columnas:**
+
+- La estructura principal se migró de una grid de PrimeFlex (`<div class="p-3"><div class="grid fluid">`) a un contenedor `<div class="layout-root">`.
+- **Panel derecho** (`.panel-right`, 380 px, fijo): contiene la tarjeta de vista previa del LCD y la tarjeta de Settings.
+- **Panel izquierdo** (`.panel-left`, flex-1, scrollable): contiene la tarjeta de Configuration con el acordeón completo de widgets/sensores.
+- El resultado es que la vista previa y los settings siempre son visibles mientras se edita la configuración.
+
+**Corrección del cambio de tema (`onThemeChange`):**
+
+- Antes: `onThemeChange()` era una función vacía (solo `console.log`).
+- Ahora:
+  1. Consulta `/api/config_dirty` para detectar cambios sin guardar.
+  2. Si hay cambios sin guardar, muestra un diálogo de confirmación (grupo `headless2`) preguntando si guardar o descartar.
+  3. En cualquier caso llama a `_doSwitch()`: guarda el tema via `api.save_config({ theme })` y recarga la página.
+
+**Overlay de carga al cambiar tema:**
+
+- Añadida propiedad reactiva `loading: { show: false, message: '' }` en `data()`.
+- Antes de llamar a `api.save_config()`, se activa `loading.show = true` con el mensaje `"Applying theme, please wait..."`.
+- El template muestra el overlay con un `<ProgressSpinner>` de PrimeVue mientras el servicio se reinicia y la página recarga.
+
+---
+
+## 3. Cambios en sensores
+
+### `sensors/cpu_freq.js` — **NUEVO**
+
+Sensor que monitorea la frecuencia actual de la CPU (core 0) vía sysfs.
+
+**Fuente de datos:** `/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq`
+
+**Configuración:**
+
+| Campo | Tipo | Descripción | Defecto |
+|---|---|---|---|
+| `max_points` | number | Número de muestras en el historial | 300 |
+
+**Campos de formato `{N}`:**
+
+| Token | Descripción | Unidad |
+|---|---|---|
+| `{0}` | Frecuencia actual del CPU | MHz |
+| `{1}` | Historial de frecuencias (para sparkline/chart) | MHz |
+
+**`min`/`max` reportado:** 0 – `scaling_max_freq` leído al inicio (auto-detectado desde sysfs).
+
+---
+
+### `sensors/cpu_temp.js` — **EXTENDIDO**
+
+Se añadió la lectura de temperaturas por core individual.
+
+**Cambios respecto al original:**
+
+- Nueva variable de módulo `_core_temps = []`.
+- Durante el walk de hwmon, ahora también recoge todos los paths cuya label empieza por `"Core "` (además del `"Package id 0"`).
+- Lee en paralelo `temp_input` de Package + todos los cores en un solo `Promise.all`.
+- `get_current_value()` actualiza `_core_temps` con los valores redondeados a entero.
+
+**Nuevos campos de formato `{N}`:**
+
+| Token | Descripción |
+|---|---|
+| `{3}` | Temperatura Core 0 (°C o °F según config) |
+| `{4}` | Temperatura Core 1 |
+| `{5}` | Temperatura Core 2 |
+| `{6}` | Temperatura Core 3 |
+
+Los tokens anteriores `{0}`, `{1}`, `{2}` no cambian (Package, historial, unidad).
+
+---
+
+### `sensors/memory.js` — **MODIFICADO**
+
+**Cambio en precisión de `usage`:**
+
+- Antes: `usage` se calculaba con `.toFixed(2)` → mostraba valores como `28.65%`.
+- Ahora: `usage` usa `.toFixed(0)` → muestra valores enteros como `28%`.
+
+El resto de la lógica y campos de formato no cambian.
+
+---
+
+### `sensors/nvme_temp.js` — **NUEVO**
+
+Sensor que monitorea la temperatura del SSD NVMe via hwmon/sysfs.
+
+**Fuente de datos:** `/sys/class/hwmon/hwmonX/` donde `name == 'nvme'`, label `'Composite'`.
+
+**Configuración:**
+
+| Campo | Tipo | Descripción | Defecto |
+|---|---|---|---|
+| `max_points` | number | Número de muestras en el historial | 300 |
+| `fahrenheit` | boolean | Mostrar en Fahrenheit | `false` |
+
+**Campos de formato `{N}`:**
+
+| Token | Descripción | Unidad |
+|---|---|---|
+| `{0}` | Temperatura Composite actual | °C o °F |
+| `{1}` | Historial de temperaturas (para sparkline/chart) | °C o °F |
+| `{2}` | Carácter de unidad | `"C"` o `"F"` |
+
+**`min`/`max` reportado:** 20 °C (68 °F) – temperatura crítica del dispositivo (leída de `temp_crit`, por defecto 84 °C si no existe el archivo).
+
+---
+
+### `sensors/space.js` — **MODIFICADO**
+
+**Compatibilidad con versiones antiguas de Node.js:**
+
+- Antes: usaba exclusivamente `fs.statfs()`, disponible solo desde Node.js ≥ 19.6.
+- Ahora: detecta en runtime si `fs.statfs` existe; si no, utiliza `exec('df -B1 <mount_point>')` como fallback para versiones anteriores de Node.
+
+**Precisión de valores:**
+
+- Añadida propiedad `precision: 0` en el objeto `_private`, de modo que los porcentajes y MB se muestran sin decimales.
+
+**Los campos de formato `{N}` no cambian.**
+
+---
+
+### `sensors/wifi_signal.js` — **NUEVO**
+
+Sensor que monitorea la señal y estado de la conexión WiFi usando `nmcli`.
+
+**Fuente de datos:** `nmcli -t -f IN-USE,SSID,SIGNAL,CHAN,RATE dev wifi`
+
+**Configuración:**
+
+| Campo | Tipo | Descripción | Defecto |
+|---|---|---|---|
+| `interface` | string | Interfaz WiFi (solo para identificación, nmcli lee la red activa) | `"wlp3s0"` |
+| `max_points` | number | Número de muestras en el historial | 300 |
+
+**Campos de formato `{N}`:**
+
+| Token | Descripción | Ejemplo |
+|---|---|---|
+| `{0}` | Nombre de la red (SSID) | `"MiRed_5G"` |
+| `{1}` | Intensidad de señal (0–100) | `72` |
+| `{2}` | Canal WiFi | `36` |
+| `{3}` | Velocidad de enlace | `"270 Mbit/s"` |
+| `{4}` | Historial de señal (para sparkline/chart) | `0,0,72,71,...` |
+| `{5}` | Estado de conexión | `"online"` / `"offline"` |
+
+**`min`/`max` reportado:** 0 – 100 (porcentaje de señal).
+
+---
+
+## 4. Cambios en API, configuración e instalador
+
+### `s1panel/api.js` — **MODIFICADO**
+
+**Corrección en `save_config`:**
+
+- Antes: el campo `theme` era completamente ignorado en `save_config()`; cambiar de tema desde la GUI no persistía ni reiniciaba el servicio.
+- Ahora: se evalúa `request.theme`. Si el valor es diferente al tema activo, se actualizan `_live_config.theme` y `_file_config.theme`, se persiste el `config.json` y se activa `_restart = true`.
+- Cuando el servicio corre como daemon (`SERVICE=true`), `_restart = true` provoca `process.exit(1)`, lo que permite a systemd reiniciar el proceso con el nuevo tema cargado.
+
+---
+
+### `s1panel/config.json` — **MODIFICADO**
+
+**Sensores añadidos:**
+
+| Sensor | Config clave |
+|---|---|
+| `sensors/cpu_freq.js` | `max_points: 300` |
+| `sensors/nvme_temp.js` | `max_points: 300`, `fahrenheit: false` |
+| `sensors/wifi_signal.js` | `interface: "wlp3s0"`, `max_points: 300` |
+
+**Otros cambios:**
+
+| Campo | Antes | Ahora |
+|---|---|---|
+| `led_config.device` | `"/dev/ttyUSB0"` | `"/dev/acemagic-led"` (symlink udev persistente) |
+| `heartbeat` | (ausente) | `60000` ms — reenvío periódico del comando LED |
+| Interfaz de red | `"enp2s0"` / `"wlp2s0"` | `"enp2s0"` / `"wlp3s0"` (nombre real de la interfaz WiFi) |
+
+---
+
+### `s1panel/install` — **REESCRITO**
+
+El script de instalación fue reescrito completamente para:
+
+1. **Usar NVM**: carga automáticamente `~/.nvm/nvm.sh` y activa Node.js v20.19.5 antes de cualquier operación.
+2. **Construir la GUI**: ejecuta `npm i` y `npm run build` en el directorio `gui/` como parte de la instalación.
+3. **Detectar la ruta de Node dinámicamente**: usa `which node` para obtener la ruta absoluta del binario y escribirla en el archivo de servicio systemd, garantizando que el servicio use la versión correcta de Node independientemente del PATH del sistema.
+4. **Gestión del servicio systemd**: genera el archivo `/etc/systemd/system/s1panel.service` usando `sudo tee`, ejecuta `daemon-reload`, `enable` y `start` en secuencia.
+
+---
+
+## 5. Archivo `.gitignore` — **NUEVO**
+
+Se añadió `.gitignore` en la raíz del repositorio con las siguientes exclusiones:
+
+| Patrón | Motivo |
+|---|---|
+| `node_modules/`, `s1panel/node_modules/`, `s1panel/gui/node_modules/` | Dependencias npm no deben versionarse |
+| `s1panel/gui/dist/` | Artefacto de build del frontend |
+| `s1panel/snap/.snapcraft/`, `parts/`, `stage/`, `prime/`, `*.snap` | Artefactos del build snap |
+| `*.log`, `npm-debug.log*` | Logs en tiempo de ejecución |
+| `.DS_Store`, `Thumbs.db` | Archivos de sistema operativo |
+| `.vscode/`, `.idea/`, `*.swp`, `*.swo` | Configuración de editores |
+| `s1panel/fonts.conf` | Generado automáticamente en runtime |

--- a/s1panel/api.js
+++ b/s1panel/api.js
@@ -830,6 +830,13 @@ function save_config(context, request) {
                 _changed = true;
             }
 
+            if (request.theme && 0 !== _live_config.theme.localeCompare(request.theme)) {
+
+                _live_config.theme = _file_config.theme = request.theme;
+                _changed = true;
+                _restart = true;
+            }
+
             if (_changed) {
                 
                 return write_file(_state.config_file, JSON.stringify(_live_config, (key, value) => '_private' === key ? undefined : value, 3)).then(() => {

--- a/s1panel/config.json
+++ b/s1panel/config.json
@@ -9,6 +9,18 @@
       {
          "name": "a simple demo portrait orientation",
          "config": "themes/simple_demo/portrait_simple.json"
+      },
+      {
+         "name": "Official Dark",
+         "config": "themes/official/portrait_dark.json"
+      },
+      {
+         "name": "Official Clock",
+         "config": "themes/official/portrait_clock.json"
+      },
+      {
+         "name": "Official Power",
+         "config": "themes/official/portrait_power.json"
       }
    ],
    "sensors": [
@@ -28,13 +40,26 @@
          "module": "sensors/cpu_temp.js",
          "config": {
             "max_points": 300,
-            "fahrenheit": true
+            "fahrenheit": false
          }
       },
       {
          "module": "sensors/cpu_power.js",
          "config": {
             "max_points": 300
+         }
+      },
+      {
+         "module": "sensors/cpu_freq.js",
+         "config": {
+            "max_points": 300
+         }
+      },
+      {
+         "module": "sensors/nvme_temp.js",
+         "config": {
+            "max_points": 300,
+            "fahrenheit": false
          }
       },
       {
@@ -47,7 +72,14 @@
       {
          "module": "sensors/network.js",
          "config": {
-            "interface": "enp4s0",
+            "interface": "wlp3s0",
+            "max_points": 300
+         }
+      },
+      {
+         "module": "sensors/wifi_signal.js",
+         "config": {
+            "interface": "wlp3s0",
             "max_points": 300
          }
       },
@@ -102,9 +134,9 @@
    "device": "1-8:1.1",
    "led_config": {
       "device": "/dev/ttyUSB0",
-      "theme": 2,
-      "speed": 3,
-      "intensity": 3
+      "theme": 3,
+      "speed": 5,
+      "intensity": 5
    },
    "portrait": true
 }

--- a/s1panel/gui/src/App.vue
+++ b/s1panel/gui/src/App.vue
@@ -435,70 +435,64 @@
 
     </Dialog>
 
-    <div class="p-3">
-        <div class="grid flud">
-            <div class="col-5">
+    <div class="layout-root">
 
-                <Card ref="preview" class="h-full w-full">
-                    <template #title>Preview</template>
+        <!-- ── DERECHA: Preview + Settings (fijos) ── -->
+        <div class="panel-right">
 
-                    <template #content>
-                        <div class="flex justify-content-center flex-wrap">
-                            <canvas ref="canvas" class="flex align-items-center justify-content-center"></canvas>
-                        </div>
-                    </template>
+            <Card ref="preview" class="w-full">
+                <template #title>Preview</template>
+                <template #content>
+                    <div class="flex justify-content-center flex-wrap">
+                        <canvas ref="canvas" class="flex align-items-center justify-content-center"></canvas>
+                    </div>
+                </template>
+            </Card>
 
-                </Card>
+            <Card class="w-full">
+                <template #title>Settings
+                    <i class="cursor-pointer pi pi-cog ml-3" style="color: #1bd443" @click="onEditConfig()"></i>
+                    <i class="cursor-pointer pi pi-bolt ml-3" style="color: #ff0000" @click="onOpenSensorManage()"></i>
+                </template>
+                <template #content>
+                    <ul class="list-none p-0 m-0">
+                        <li class="flex align-items-center py-2 px-2 border-top-1 surface-border flex-nowrap">
+                            <div class="text-500 w-5rem font-medium">IP</div>
+                            <div class="text-900 w-full text-overflow-ellipsis overflow-hidden">{{ config?.listen }} <Tag v-if="!connected" class="ml-2" severity="danger" value="Lost Connection" rounded></Tag></div>
+                        </li>
+                        <li class="flex align-items-center py-2 px-2 border-top-1 surface-border flex-nowrap">
+                            <div class="text-500 w-5rem font-medium">Theme</div>
+                            <div class="text-900 w-full text-overflow-ellipsis overflow-hidden">{{ getThemeName(config?.theme) }}</div>
+                        </li>
+                        <li class="flex align-items-center py-2 px-2 border-top-1 surface-border flex-nowrap">
+                            <div class="text-500 w-5rem font-medium">Poll</div>
+                            <div class="text-900 w-full">{{ config?.poll }} ms</div>
+                        </li>
+                        <li class="flex align-items-center py-2 px-2 border-top-1 surface-border flex-nowrap">
+                            <div class="text-500 w-5rem font-medium">Refresh</div>
+                            <div class="text-900 w-full">{{ config?.refresh }} ms</div>
+                        </li>
+                        <li class="flex align-items-center py-2 px-2 border-top-1 surface-border flex-nowrap">
+                            <div class="text-500 w-5rem font-medium">Heartbeat</div>
+                            <div class="text-900 w-full">{{ config?.heartbeat }} ms</div>
+                        </li>
+                        <li class="flex align-items-center py-2 px-2 border-top-1 surface-border flex-nowrap">
+                            <div class="text-500 w-5rem font-medium">LCD</div>
+                            <div class="text-900 w-full text-overflow-ellipsis overflow-hidden">{{ config?.device }}</div>
+                        </li>
+                        <li class="flex align-items-center py-2 px-2 border-top-1 surface-border flex-nowrap">
+                            <div class="text-500 w-5rem font-medium">LED</div>
+                            <div class="text-900 w-full text-overflow-ellipsis overflow-hidden">{{ config?.led_config.device }}</div>
+                        </li>
+                    </ul>
+                </template>
+            </Card>
 
-            </div>
+        </div>
 
-            <div class="col-7">
-
-                <Card class="h-full">
-                    <template #title>Settings 
-                        <i class="cursor-pointer pi pi-cog ml-3" style="color: #1bd443" @click="onEditConfig()"></i>
-                        <i class="cursor-pointer pi pi-bolt ml-3" style="color: #ff0000" @click="onOpenSensorManage()"></i>
-                    </template>
-                    <template #content>
-
-                        <ul class="list-none p-0 m-0">
-                            <li class="flex align-items-center py-3 px-2 border-top-1 surface-border flex-nowrap">
-                                <div class="text-500 w-6 md:w-3 font-medium">IP</div>
-                                <div class="text-900 w-full md:w-7 md:flex-order-0 flex-order-1">{{ config?.listen }} <Tag v-if="!connected" class="ml-2" severity="danger" value="Lost Connection" rounded></Tag></div>
-                            </li>
-                            <li class="flex align-items-center py-3 px-2 border-top-1 surface-border flex-nowrap">
-                                <div class="text-500 w-6 md:w-3 font-medium">Theme</div>
-                                <div class="text-900 w-full md:w-7 md:flex-order-0 flex-order-1">{{ getThemeName(config?.theme) }}</div>
-                            </li>
-                            <li class="flex align-items-center py-3 px-2 border-top-1 surface-border flex-nowrap">
-                                <div class="text-500 w-6 md:w-3 font-medium">Poll</div>
-                                <div class="text-900 w-full md:w-7 md:flex-order-0 flex-order-1">{{ config?.poll }} ms</div>
-                            </li>        
-                            <li class="flex align-items-center py-3 px-2 border-top-1 surface-border flex-nowrap">
-                                <div class="text-500 w-6 md:w-3 font-medium">Refresh</div>
-                                <div class="text-900 w-full md:w-7 md:flex-order-0 flex-order-1">{{ config?.refresh }} ms</div>
-                            </li>
-                            <li class="flex align-items-center py-3 px-2 border-top-1 surface-border flex-nowrap">
-                                <div class="text-500 w-6 md:w-3 font-medium">Heartbeat</div>
-                                <div class="text-900 w-full md:w-7 md:flex-order-0 flex-order-1">{{ config?.heartbeat }} ms</div>
-                            </li>
-                            <li class="flex align-items-center py-3 px-2 border-top-1 surface-border flex-nowrap">
-                                <div class="text-500 w-6 md:w-3 font-medium">LCD</div>
-                                <div class="text-900 w-full md:w-7 md:flex-order-0 flex-order-1">{{ config?.device }}</div>
-                            </li> 
-                            <li class="flex align-items-center py-3 px-2 border-top-1 surface-border flex-nowrap">
-                                <div class="text-500 w-6 md:w-3 font-medium">LED</div>
-                                <div class="text-900 w-full md:w-7 md:flex-order-0 flex-order-1">{{ config?.led_config.device }}</div>
-                            </li>                 
-                        </ul>	
-
-                    </template>
-                </Card>
-
-            </div>
-
-            <div class="col-12">
-                <Card>
+        <!-- ── IZQUIERDA: Configuración (scrollable) ── -->
+        <div class="panel-left">
+            <Card>
                     <template #title>
                         <div class="flex justify-content-between flex-nowrap">
                             <div class="flex align-items-center justify-content-center gap-3">
@@ -765,7 +759,14 @@
                                             
                     </template>
                 </Card>
-            </div>
+        </div>
+
+    </div>
+
+    <div v-if="loading.show" class="loading-overlay">
+        <div class="loading-content">
+            <ProgressSpinner strokeWidth="4" animationDuration=".8s"/>
+            <p class="mt-3">{{ loading.message }}</p>
         </div>
     </div>
 
@@ -906,7 +907,8 @@ export default {
             methods: [
                 { id: 'redraw', name: 'Redraw' },
                 { id: 'update', name: 'Update' },
-            ]
+            ],
+            loading: { show: false, message: '' }
         };
     },
     mounted() {
@@ -1366,6 +1368,14 @@ export default {
 
             if (this.config.theme_list.length > 1) {
 
+                const _doSwitch = () => {
+                    this.loading = { show: true, message: 'Applying theme, please wait...' };
+                    this.config.theme = this.edit_theme;
+                    api.save_config({ theme: this.edit_theme }).then(() => {
+                        window.location.reload();
+                    });
+                };
+
                 return api.fetch_config_dirty().then(response => {
 
                     if (response.unsaved_changes) {
@@ -1375,15 +1385,15 @@ export default {
                             header: 'Would you like to save your changes?',
                             message: 'Switching themes will discard any unsaved changes!',
                             accept: () => {
-                                console.log('save changes and switch theme');
+                                api.theme_save().then(_doSwitch);
                             },
                             reject: () => {
-                                console.log('do nothing');
+                                _doSwitch();
                             }
                         });
                     }
                     else {
-                        console.log('switch theme');
+                        _doSwitch();
                     }
                 });
             }

--- a/s1panel/gui/src/assets/main.css
+++ b/s1panel/gui/src/assets/main.css
@@ -2,10 +2,13 @@
 
 html {
   font-size: 13px;
+  height: 100%;
+  overflow: hidden;
 }
 
 body {
-  min-height: 100vh;
+  height: 100%;
+  overflow: hidden;
   max-width: 100vw;
   color: #fff;
   background: radial-gradient(
@@ -32,4 +35,59 @@ body {
   background-repeat: no-repeat;
   background-attachment: fixed;
   background-size: contain;
+}
+
+/* ── Two-column layout ── */
+.layout-root {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+}
+
+.panel-left {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.panel-right {
+  width: 380px;
+  min-width: 380px;
+  height: 100vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-sizing: border-box;
+}
+
+/* scrollbar styling for panels */
+.panel-left::-webkit-scrollbar,
+.panel-right::-webkit-scrollbar { width: 5px; }
+.panel-left::-webkit-scrollbar-track,
+.panel-right::-webkit-scrollbar-track { background: transparent; }
+.panel-left::-webkit-scrollbar-thumb,
+.panel-right::-webkit-scrollbar-thumb { background: #444; border-radius: 3px; }
+
+/* ── Loading overlay ── */
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loading-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: #fff;
+  font-size: 1rem;
 }

--- a/s1panel/install
+++ b/s1panel/install
@@ -1,4 +1,36 @@
 #!/bin/bash
+
+# Define la versión de Node.js
+NODE_VERSION="20.19.5"
+
+# Carga NVM
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+    . "$NVM_DIR/nvm.sh"
+    echo "NVM cargado..."
+else
+    echo "Error: No se encontró NVM en $NVM_DIR."
+    echo "Asegúrate de tener NVM instalado para tu usuario."
+    exit 1
+fi
+
+# Asegura que la versión específica esté instalada y en uso
+echo "Asegurando el uso de Node v$NODE_VERSION..."
+nvm install $NODE_VERSION > /dev/null
+nvm use $NODE_VERSION
+if [ $? -ne 0 ]; then
+    echo "Error: No se pudo activar la versión $NODE_VERSION de Node."
+    exit 1
+fi
+echo "Confirmado, usando: $(node -v)"
+
+# Obtiene la ruta absoluta del ejecutable 'node' para esa versión
+NODE_PATH=$(which node)
+if [ -z "$NODE_PATH" ]; then
+    echo "Error: No se pudo encontrar la ruta de Node."
+    exit 1
+fi
+
 CURRENT_DIR=$(pwd)
 
 make_service()
@@ -6,9 +38,11 @@ make_service()
 cat <<EOF
 [Unit]
 \rDescription="S1 Panel"
+\rAfter=network-online.target
+\rWants=network-online.target
 \r
 \r[Service]
-\rExecStart=/usr/bin/node main.js
+\rExecStart=$NODE_PATH main.js
 \rWorkingDirectory=$CURRENT_DIR
 \rRestart=always
 \rRestartSec=10
@@ -22,17 +56,33 @@ EOF
 }
 
 echo "Home Directory is $CURRENT_DIR"
+echo "La ruta de Node para el servicio será: $NODE_PATH"
+
+# --- FASE DE CONSTRUCCIÓN (como usuario normal) ---
+echo "Instalando dependencias (npm i)..."
 npm i
 (cd gui; npm i)
-echo "Building GUI"
+echo "Construyendo GUI (npm run build)..."
 (cd gui; npm run build)
-echo "Install Service..."
-echo -e "$(make_service)" > /etc/systemd/system/s1panel.service
+
+# --- FASE DE INSTALACIÓN (con sudo) ---
+echo "Instalando el servicio (se requerirá sudo)..."
+
+# Usamos 'sudo tee' para escribir el archivo como root
+echo -e "$(make_service)" | sudo tee /etc/systemd/system/s1panel.service > /dev/null
+if [ $? -ne 0 ]; then
+    echo "Error al escribir el archivo de servicio. ¿Cancelaste el sudo?"
+    exit 1
+fi
+
 echo "Reload Service Daemon..."
-systemctl daemon-reload
+sudo systemctl daemon-reload
+
 echo "Enable s1panel..."
-systemctl enable s1panel.service
+sudo systemctl enable s1panel.service
+
 echo "Start s1panel..."
-systemctl start s1panel.service
+sudo systemctl start s1panel.service
+
 echo "Done!"
-systemctl status s1panel.service
+sudo systemctl status s1panel.service

--- a/s1panel/sensors/cpu_freq.js
+++ b/s1panel/sensors/cpu_freq.js
@@ -1,0 +1,140 @@
+'use strict';
+/*!
+ * s1panel - sensor/cpu_freq
+ * Copyright (c) 2024-2025
+ * GPL-3 Licensed
+ */
+const fs = require('fs');
+const logger = require('../logger');
+
+var _fault = false;
+var _max_points = 10;
+var _last_sampled = 0;
+var _history = [];
+var _max_freq = 3400;
+
+function read_file(path) {
+
+    return new Promise((fulfill, reject) => {
+
+        fs.readFile(path, 'utf8', (err, data) => {
+
+            if (err) {
+                return reject(err);
+            }
+
+            fulfill(data.trim());
+        });
+    });
+}
+
+function cpu_freq() {
+
+    return new Promise(fulfill => {
+
+        const _path = '/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq';
+
+        read_file(_path).then(data => {
+
+            fulfill({ mhz: Math.round(Number(data) / 1000) });
+
+        }, err => {
+
+            if (!_fault) {
+                logger.error('cpu_freq: failed to read ' + _path + ': ' + err.message);
+                _fault = true;
+            }
+            fulfill();
+        });
+    });
+}
+
+function sample(rate, format) {
+
+    return new Promise(fulfill => {
+
+        const _diff = Math.floor(Number(process.hrtime.bigint()) / 1000000) - _last_sampled;
+        var _dirty = false;
+        var _freq_promise = Promise.resolve();
+
+        if (!_last_sampled || _diff > rate) {
+
+            _last_sampled = Math.floor(Number(process.hrtime.bigint()) / 1000000);
+            _freq_promise = cpu_freq();
+            _dirty = true;
+        }
+
+        _freq_promise.then(result => {
+
+            if (result && _dirty) {
+
+                if (!_history.length) {
+                    for (var i = 0; i < _max_points; i++) {
+                        _history.push(0);
+                    }
+                }
+
+                _history.push(result.mhz);
+                _history.shift();
+            }
+
+            const _output = format.replace(/{(\d+)}/g, function (match, number) {
+
+                switch (number) {
+                    case '0':
+                        return _history[_history.length - 1] || 0;
+                    case '1':
+                        return _history.join();
+                    default:
+                        return 'null';
+                }
+            });
+
+            fulfill({ value: _output, min: 0, max: _max_freq });
+        });
+    });
+}
+
+function init(config) {
+
+    if (config) {
+        _max_points = config.max_points || 10;
+    }
+
+    const _max_path = '/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq';
+
+    fs.readFile(_max_path, 'utf8', (err, data) => {
+
+        if (!err) {
+            _max_freq = Math.round(Number(data.trim()) / 1000);
+        }
+
+        logger.info('initialize: cpu freq max ' + _max_freq + 'MHz, max_points: ' + _max_points);
+    });
+
+    return 'cpu_freq';
+}
+
+function stop() {
+    return Promise.resolve();
+}
+
+function settings() {
+    return {
+        name: 'cpu_freq',
+        description: 'cpu frequency monitor',
+        icon: 'pi-microchip',
+        multiple: false,
+        ident: [],
+        fields: [
+            { name: 'max_points', type: 'number', value: 300 }
+        ]
+    };
+}
+
+module.exports = {
+    init,
+    settings,
+    sample,
+    stop
+};

--- a/s1panel/sensors/cpu_temp.js
+++ b/s1panel/sensors/cpu_temp.js
@@ -16,6 +16,7 @@ var _last_sampled = 0;
 var _history = [];
 var _max_temp = 0;
 var _min_temp = 0;
+var _core_temps = [];
 
 function read_file(path) {
   
@@ -94,19 +95,25 @@ function cpu_temp() {
                 var _temp_path = null;
                 var _temp_found = false;
 
+                        var _core_paths = [];
+
                 return walk_directory(_path_coretemp, fullpath => {
-                    
+
                     if (fullpath.includes('temp') && fullpath.includes('label')) {
 
                         return read_file(fullpath).then(name => {
-                        
+
                             if (name.startsWith('Package id 0')) {
                                 _temp_path = fullpath;
                                 _temp_found = true;
                             }
-                        }, reject);
+                            else if (name.startsWith('Core ')) {
+                                _core_paths.push(fullpath.replace('_label', '_input'));
+                            }
+
+                        }, () => Promise.resolve());
                     }
-                    
+
                     return Promise.resolve();
 
                 }).then(() => {
@@ -114,16 +121,27 @@ function cpu_temp() {
                     if (_temp_found) {
 
                         const _input_path = _temp_path.replace('_label', '_input');
-                        const _max_path = _temp_path.replace('_label', '_max');
+                        const _max_path   = _temp_path.replace('_label', '_max');
 
-                        return Promise.all([read_file(_input_path), read_file(_max_path) ]).then(values => {
+                        const _reads = [
+                            read_file(_input_path),
+                            read_file(_max_path),
+                            ..._core_paths.sort().map(p => read_file(p))
+                        ];
 
-                            var _value = Number(values[0]) / 1000;
-                            var _max = Number(values[1]) / 1000;
+                        return Promise.all(_reads).then(values => {
 
-                            fulfill({ 
-                                value: _fahrenheit ? celsius_fahrenheit(_value) : _value, 
-                                max: _fahrenheit ? celsius_fahrenheit(_max) : _max 
+                            const _value = Number(values[0]) / 1000;
+                            const _max   = Number(values[1]) / 1000;
+                            const _cores = values.slice(2).map(v => {
+                                const c = Number(v) / 1000;
+                                return _fahrenheit ? celsius_fahrenheit(c) : c;
+                            });
+
+                            fulfill({
+                                value: _fahrenheit ? celsius_fahrenheit(_value) : _value,
+                                max:   _fahrenheit ? celsius_fahrenheit(_max)   : _max,
+                                cores: _cores
                             });
 
                         }, reject);
@@ -167,6 +185,10 @@ function get_current_value(json) {
         logger.info('initialize: cpu temp min set to ' + _min_temp);
     }
 
+    if (json.cores && json.cores.length) {
+        _core_temps = json.cores.map(c => c.toFixed(0));
+    }
+
     return json.value;
 }
 
@@ -207,15 +229,27 @@ function sample(rate, format) {
         
                 switch (number) {
 
-                    case '0':   // degrees
+                    case '0':   // package temp (current)
                         return _history[_history.length - 1];
 
                     case '1':   // history
-                        return _history.join();  
+                        return _history.join();
 
-                    case '2':
-                        return _fahrenheit ? 'F' : 'C';  
-                                 
+                    case '2':   // unit
+                        return _fahrenheit ? 'F' : 'C';
+
+                    case '3':   // Core 0
+                        return _core_temps[0] || 'null';
+
+                    case '4':   // Core 1
+                        return _core_temps[1] || 'null';
+
+                    case '5':   // Core 2
+                        return _core_temps[2] || 'null';
+
+                    case '6':   // Core 3
+                        return _core_temps[3] || 'null';
+
                     default:
                         return 'null';
                 }

--- a/s1panel/sensors/memory.js
+++ b/s1panel/sensors/memory.js
@@ -97,7 +97,7 @@ function calc_memory_usage(current) {
         free: _current_free * 1024,
         cached: _current_cached * 1024,
         active: _active * 1024,
-        usage:  ((_active / _current_total) * 100.0).toFixed(2),
+        usage:  ((_active / _current_total) * 100.0).toFixed(0),
         swap_total: _current_swap_total * 1024,
         swap_used: _swap_used * 1024,
         swap: ((_swap_used / _current_swap_total) * 100.0).toFixed(2)

--- a/s1panel/sensors/nvme_temp.js
+++ b/s1panel/sensors/nvme_temp.js
@@ -1,0 +1,266 @@
+'use strict';
+/*!
+ * s1panel - sensor/nvme_temp
+ * Copyright (c) 2024-2025 Tomasz Jaworski
+ * GPL-3 Licensed
+ */
+const fs        = require('fs');
+const path      = require('path');
+const logger    = require('../logger');
+
+var _fault = false;
+
+var _max_points = 10;
+var _fahrenheit = false;
+var _last_sampled = 0;
+var _history = [];
+var _max_temp = 0;
+var _min_temp = 0;
+
+function read_file(path) {
+
+    return new Promise((fulfill, reject) => {
+
+        fs.readFile(path, 'utf8', (err, data) => {
+
+            if (err) {
+                return reject(err);
+            }
+
+            fulfill(data);
+        });
+    });
+}
+
+function celsius_fahrenheit(c) {
+    return (c * 9/5) + 32;
+}
+
+function walk_directory(dir, cb) {
+
+    return new Promise((fulfill, reject) => {
+
+        fs.readdir(dir, (err, files) => {
+
+            if (err) {
+                return reject(err);
+            }
+
+            var _promises = [];
+
+            files.forEach(file => {
+                _promises.push(cb(path.join(dir, file)));
+            });
+
+            Promise.all(_promises).then(fulfill, reject);
+        });
+    });
+}
+
+function nvme_temp() {
+
+    return new Promise((fulfill, reject) => {
+
+        const _hwmon = '/sys/class/hwmon/';
+
+        // /sys/class/hwmon/hwmonX/name === 'nvme'
+        // /sys/class/hwmon/hwmonX/temp1_label === 'Composite'
+        // /sys/class/hwmon/hwmonX/temp1_input  e.g. 57850 / 1000 = 57.85°C
+
+        var _found_nvme = false;
+        var _path_nvme = null;
+
+        walk_directory(_hwmon, fullpath => {
+
+            const _hwmon_name = path.join(fullpath, 'name');
+
+            return read_file(_hwmon_name).then(name => {
+
+                if (name.trim() === 'nvme') {
+                    _path_nvme = fullpath;
+                    _found_nvme = true;
+                }
+
+                return Promise.resolve();
+
+            }, () => Promise.resolve());
+
+        }).then(() => {
+
+            if (!_found_nvme) {
+                return fulfill();
+            }
+
+            var _temp_path = null;
+            var _temp_found = false;
+
+            return walk_directory(_path_nvme, fullpath => {
+
+                if (fullpath.includes('temp') && fullpath.includes('label')) {
+
+                    return read_file(fullpath).then(name => {
+
+                        if (name.trim() === 'Composite') {
+                            _temp_path = fullpath;
+                            _temp_found = true;
+                        }
+
+                    }, () => Promise.resolve());
+                }
+
+                return Promise.resolve();
+
+            }).then(() => {
+
+                if (!_temp_found) {
+                    return fulfill();
+                }
+
+                const _input_path = _temp_path.replace('_label', '_input');
+                const _max_path   = _temp_path.replace('_label', '_max');
+                const _crit_path  = _temp_path.replace('_label', '_crit');
+
+                return Promise.all([
+                    read_file(_input_path),
+                    read_file(_max_path),
+                    read_file(_crit_path).catch(() => '84000')
+                ]).then(values => {
+
+                    const _value = Number(values[0]) / 1000;
+                    const _max   = Number(values[1]) / 1000;
+                    const _crit  = Number(values[2]) / 1000;
+
+                    fulfill({
+                        value: _fahrenheit ? celsius_fahrenheit(_value) : _value,
+                        max:   _fahrenheit ? celsius_fahrenheit(_max)   : _max,
+                        crit:  _fahrenheit ? celsius_fahrenheit(_crit)  : _crit
+                    });
+
+                }, reject);
+
+            }, reject);
+
+        }, reject);
+    });
+}
+
+function get_current_value(json) {
+
+    if (!_max_temp) {
+        _max_temp = json.crit || json.max || (_fahrenheit ? 185.0 : 85.0);
+        logger.info('initialize: nvme temp max set to ' + _max_temp);
+    }
+
+    if (!_min_temp) {
+        _min_temp = _fahrenheit ? 68.0 : 20.0;
+        logger.info('initialize: nvme temp min set to ' + _min_temp);
+    }
+
+    return json.value;
+}
+
+function sample(rate, format) {
+
+    return new Promise((fulfill, reject) => {
+
+        const _diff = Math.floor(Number(process.hrtime.bigint()) / 1000000) - _last_sampled;
+        var _dirty = false;
+        var _temp_promise = Promise.resolve();
+
+        if (!_last_sampled || _diff > rate) {
+
+            _last_sampled = Math.floor(Number(process.hrtime.bigint()) / 1000000);
+
+            _temp_promise = nvme_temp();
+            _dirty = true;
+        }
+
+        _temp_promise.then(result => {
+
+            if (result && _dirty) {
+
+                var _value = get_current_value(result);
+
+                if (!_history.length) {
+
+                    for (var i = 0; i < _max_points; i++) {
+                        _history.push(0);
+                    }
+                }
+
+                _history.push(_value.toFixed(0));
+                _history.shift();
+            }
+
+            const _output = format.replace(/{(\d+)}/g, function (match, number) {
+
+                switch (number) {
+
+                    case '0':   // composite temp (current)
+                        return _history[_history.length - 1];
+
+                    case '1':   // history
+                        return _history.join();
+
+                    case '2':   // unit
+                        return _fahrenheit ? 'F' : 'C';
+
+                    default:
+                        return 'null';
+                }
+            });
+
+            fulfill({ value: _output, min: _min_temp, max: _max_temp });
+
+        }, err => {
+
+            if (!_fault) {
+                logger.error('nvme_temp: sensor reported error: ' + err);
+                _fault = true;
+            }
+
+            fulfill({ value: 0, min: 0, max: 0 });
+        });
+    });
+}
+
+function init(config) {
+
+    if (config) {
+        _max_points = config.max_points || 10;
+        _fahrenheit = config.fahrenheit || false;
+    }
+
+    logger.info('initialize: nvme temp max points set to ' + _max_points);
+
+    if (_fahrenheit) {
+        logger.info('initialize: nvme temp set to use fahrenheit');
+    }
+
+    return 'nvme_temp';
+}
+
+function stop() {
+    return Promise.resolve();
+}
+
+function settings() {
+    return {
+        name: 'nvme_temp',
+        description: 'NVMe SSD temperature monitor (Composite)',
+        icon: 'pi-database',
+        multiple: false,
+        ident: [],
+        fields: [
+            { name: 'max_points', type: 'number', value: 300 },
+            { name: 'fahrenheit', type: 'boolean', value: false },
+        ]
+    };
+}
+
+module.exports = {
+    init,
+    settings,
+    sample,
+    stop
+};

--- a/s1panel/sensors/space.js
+++ b/s1panel/sensors/space.js
@@ -3,10 +3,11 @@
  * s1panel - sensor/space
  * Copyright (c) 2024-2025 Tomasz Jaworski
  * GPL-3 Licensed
- * 
+ *
  * inspired by https://github.com/Ex161/AceMagic-S1-LED-TFT-Linux/blob/main/s1panel/sensors/storage_space.js
  */
 const fs = require('fs');
+const { exec } = require('child_process');
 
 const logger = require('../logger');
 
@@ -29,25 +30,51 @@ function space_info(path) {
 
     return new Promise((fulfill, reject) => {
 
-        fs.statfs(path, (err, stats) => {
+        // Try fs.statfs if available (Node.js >= 19.6.0)
+        if (typeof fs.statfs === 'function') {
+            fs.statfs(path, (err, stats) => {
 
-            var _info = {
-                used: 0,
-                avail: 0,
-                size: 0,
-            };
+                var _info = {
+                    used: 0,
+                    avail: 0,
+                    size: 0,
+                };
 
-            if (!err) {
-                const _total_bytes = stats.blocks * stats.bsize;
-                const _free_bytes = stats.bfree * stats.bsize;
+                if (!err) {
+                    const _total_bytes = stats.blocks * stats.bsize;
+                    const _free_bytes = stats.bfree * stats.bsize;
 
-                _info.used = _total_bytes - _free_bytes;
-                _info.avail = _free_bytes;
-                _info.size = _total_bytes;
-            }
-            
-            fulfill(_info);
-        });
+                    _info.used = _total_bytes - _free_bytes;
+                    _info.avail = _free_bytes;
+                    _info.size = _total_bytes;
+                }
+
+                fulfill(_info);
+            });
+        } else {
+            // Fallback to df command for older Node.js versions
+            exec(`df -B1 ${path}`, (err, stdout, stderr) => {
+                var _info = {
+                    used: 0,
+                    avail: 0,
+                    size: 0,
+                };
+
+                if (!err && stdout) {
+                    const lines = stdout.trim().split('\n');
+                    if (lines.length > 1) {
+                        const parts = lines[1].split(/\s+/);
+                        if (parts.length >= 4) {
+                            _info.size = parseInt(parts[1]) || 0;
+                            _info.used = parseInt(parts[2]) || 0;
+                            _info.avail = parseInt(parts[3]) || 0;
+                        }
+                    }
+                }
+
+                fulfill(_info);
+            });
+        }
     });
 }
 

--- a/s1panel/sensors/wifi_signal.js
+++ b/s1panel/sensors/wifi_signal.js
@@ -1,0 +1,170 @@
+'use strict';
+/*!
+ * s1panel - sensor/wifi_signal
+ * Copyright (c) 2024-2025 Tomasz Jaworski
+ * GPL-3 Licensed
+ */
+const { exec }  = require('child_process');
+const logger    = require('../logger');
+
+var _fault      = false;
+var _max_points = 10;
+var _last_sampled = 0;
+var _interface  = 'wlp3s0';
+
+var _ssid       = '--';
+var _signal     = 0;
+var _channel    = 0;
+var _rate       = '--';
+var _connected  = false;
+var _history    = [];
+
+function read_wifi() {
+
+    return new Promise((fulfill) => {
+
+        exec('nmcli -t -f IN-USE,SSID,SIGNAL,CHAN,RATE dev wifi', (err, stdout) => {
+
+            if (err) {
+                return fulfill(null);
+            }
+
+            var _active = null;
+
+            stdout.split('\n').forEach(line => {
+
+                if (line.startsWith('*:')) {
+                    _active = line;
+                }
+            });
+
+            if (!_active) {
+                return fulfill({ connected: false, ssid: '--', signal: 0, channel: 0, rate: '--' });
+            }
+
+            // format: *:SSID:SIGNAL:CHAN:RATE
+            const _parts = _active.split(':');
+
+            fulfill({
+                connected : true,
+                ssid      : _parts[1] || '--',
+                signal    : parseInt(_parts[2]) || 0,   // 0-100 %
+                channel   : parseInt(_parts[3]) || 0,
+                rate      : (_parts[4] || '--').trim()
+            });
+        });
+    });
+}
+
+function sample(rate, format) {
+
+    return new Promise((fulfill) => {
+
+        const _diff = Math.floor(Number(process.hrtime.bigint()) / 1000000) - _last_sampled;
+        var _dirty  = false;
+        var _promise = Promise.resolve();
+
+        if (!_last_sampled || _diff > rate) {
+
+            _last_sampled = Math.floor(Number(process.hrtime.bigint()) / 1000000);
+            _promise = read_wifi();
+            _dirty = true;
+        }
+
+        _promise.then(result => {
+
+            if (result && _dirty) {
+
+                _connected = result.connected;
+                _ssid      = result.ssid;
+                _signal    = result.signal;
+                _channel   = result.channel;
+                _rate      = result.rate;
+
+                if (!_history.length) {
+                    for (var i = 0; i < _max_points; i++) {
+                        _history.push(0);
+                    }
+                }
+
+                _history.push(_signal);
+                _history.shift();
+            }
+
+            const _output = format.replace(/{(\d+)}/g, function (match, number) {
+
+                switch (number) {
+
+                    case '0':   // SSID
+                        return _ssid;
+
+                    case '1':   // signal % (0-100)
+                        return _signal;
+
+                    case '2':   // channel
+                        return _channel;
+
+                    case '3':   // link rate (e.g. "270 Mbit/s")
+                        return _rate;
+
+                    case '4':   // signal history (for sparkline)
+                        return _history.join();
+
+                    case '5':   // connection status
+                        return _connected ? 'online' : 'offline';
+
+                    default:
+                        return 'null';
+                }
+            });
+
+            fulfill({ value: _output, min: 0, max: 100 });
+
+        }, err => {
+
+            if (!_fault) {
+                logger.error('wifi_signal: error reading wifi info: ' + err);
+                _fault = true;
+            }
+
+            fulfill({ value: format.replace(/{(\d+)}/g, '0'), min: 0, max: 100 });
+        });
+    });
+}
+
+function init(config) {
+
+    if (config) {
+        _max_points = config.max_points || 10;
+        _interface  = config.interface  || 'wlp3s0';
+    }
+
+    logger.info('initialize: wifi_signal interface=' + _interface + ' max_points=' + _max_points);
+
+    return 'wifi_' + _interface;
+}
+
+function stop() {
+    return Promise.resolve();
+}
+
+function settings() {
+    return {
+        name        : 'wifi_signal',
+        description : 'WiFi signal strength and connection info',
+        icon        : 'pi-wifi',
+        multiple    : true,
+        ident       : ['interface'],
+        fields: [
+            { name: 'interface',  type: 'string', value: 'wlp3s0' },
+            { name: 'max_points', type: 'number', value: 300 }
+        ]
+    };
+}
+
+module.exports = {
+    init,
+    settings,
+    sample,
+    stop
+};

--- a/s1panel/themes/simple_demo/portrait_simple.json
+++ b/s1panel/themes/simple_demo/portrait_simple.json
@@ -224,7 +224,7 @@
                   "height": 10
                },
                "sensor": true,
-               "value": "network_enp4s0",
+               "value": "network_enp2s0",
                "format": "{17}",
                "refresh": 1000,
                "debug_frame": false,
@@ -488,7 +488,7 @@
                   "height": 35
                },
                "sensor": true,
-               "value": "network_enp4s0",
+               "value": "network_enp2s0",
                "format": "{2}",
                "refresh": 1000,
                "debug_frame": false,
@@ -508,7 +508,7 @@
                   "height": 10
                },
                "sensor": true,
-               "value": "network_enp4s0",
+               "value": "network_enp2s0",
                "format": "{1}",
                "refresh": 1000,
                "debug_frame": false,
@@ -549,7 +549,7 @@
                   "height": 15
                },
                "sensor": true,
-               "value": "network_enp4s0",
+               "value": "network_enp2s0",
                "format": "{15}",
                "refresh": 1000,
                "debug_frame": false,
@@ -568,7 +568,7 @@
                   "height": 35
                },
                "sensor": true,
-               "value": "network_enp4s0",
+               "value": "network_enp2s0",
                "format": "{5}",
                "refresh": 1000,
                "debug_frame": false,
@@ -588,7 +588,7 @@
                   "height": 10
                },
                "sensor": true,
-               "value": "network_enp4s0",
+               "value": "network_enp2s0",
                "format": "{4}",
                "refresh": 1000,
                "debug_frame": false,
@@ -629,7 +629,7 @@
                   "height": 15
                },
                "sensor": true,
-               "value": "network_enp4s0",
+               "value": "network_enp2s0",
                "format": "{16}",
                "refresh": 1000,
                "debug_frame": false,


### PR DESCRIPTION
- New sensors: cpu_freq, nvme_temp, wifi_signal
- Extended cpu_temp with per-core temperatures ({3}–{6})
- Fixed memory usage precision to integer, space.js Node <19.6 compat
- Fixed theme change in GUI (save, confirm dialog, loading overlay)
- Two-column layout for web UI (config left, preview+settings right)
- api.js: theme change now persists and triggers service restart
- config.json: added new sensors, udev symlink, heartbeat
- Installer rewritten to use NVM and build GUI automatically
- Added .gitignore